### PR TITLE
[TimePicker] update on defaultTime new prop.

### DIFF
--- a/src/time-picker/time-picker.jsx
+++ b/src/time-picker/time-picker.jsx
@@ -108,6 +108,17 @@ const TimePicker = React.createClass({
       muiTheme: this.context.muiTheme || getMuiTheme(),
     };
   },
+  
+  componentWillReceiveProps(nextProps, nextContext) {
+    const newState = this.state;
+    if (nextContext.muiTheme) {
+      newState.muiTheme = nextContext.muiTheme; 
+    }
+    if (!Date.isEqualTime(this.state.time, nextProps.defaultTime)) {
+      newState.time = nextProps.defaultTime;
+    }
+    this.setState(newState);
+  },
 
   windowListeners: {
     'keyup': '_handleWindowKeyUp',


### PR DESCRIPTION
If a TimePicker instance is already mounted and a new defaultTime is passed to it, the `time` state value doesn't update.

There was already a pull request aiming to fix this and other issues for this component at callemall/material-ui#2027, but it has been waiting for review since Nov 24, 2015.
